### PR TITLE
fix(mcp): add SSE heartbeat and dead-connection cleanup

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -25,6 +25,9 @@ export class McpService {
   private isRunning = false;
   private toolCategories: ToolCategory[] = [];
   private httpServer: http.Server;
+  // Interval for SSE keep-alive comments. Keeps idle proxies/NAT from reaping
+  // the stream and lets a failed write reveal a dead socket. See issue #8.
+  private readonly SSE_HEARTBEAT_INTERVAL_MS = 15000;
 
   constructor(
     public config: ConfigService,
@@ -87,14 +90,46 @@ export class McpService {
         "/messages",
         res as unknown as ServerResponse<IncomingMessage>,
       );
-      this.logger.info(`New SSE connection established for sessionId ${transport.sessionId}`);
+      const sessionId = transport.sessionId;
+      this.logger.info(`New SSE connection established for sessionId ${sessionId}`);
 
-      this.transports[transport.sessionId] = transport;
-      res.on("close", () => {
-        delete this.transports[transport.sessionId];
+      this.transports[sessionId] = transport;
+
+      let heartbeat: ReturnType<typeof setInterval> | undefined;
+      const cleanup = () => {
+        if (heartbeat) {
+          clearInterval(heartbeat);
+          heartbeat = undefined;
+        }
+        if (this.transports[sessionId]) {
+          delete this.transports[sessionId];
+          this.logger.info(`SSE connection closed for sessionId ${sessionId}`);
+        }
+      };
+
+      res.on("close", cleanup);
+      res.on("error", (err) => {
+        this.logger.error(`SSE connection error for sessionId ${sessionId}:`, err);
+        cleanup();
       });
 
+      // Connect first so the SDK writes the SSE headers and initial endpoint
+      // event before we emit any keep-alive comments.
       await this.server.connect(transport);
+
+      // Periodic SSE comment keeps the stream alive across idle gaps (e.g. while
+      // a long command runs) and surfaces a dead socket via a failed write,
+      // instead of silently writing a tool result into a closed connection.
+      heartbeat = setInterval(() => {
+        try {
+          if (!res.write(": ping\n\n") && (res.writableEnded || res.destroyed)) {
+            cleanup();
+          }
+        } catch (err) {
+          this.logger.error(`SSE heartbeat failed for sessionId ${sessionId}:`, err);
+          cleanup();
+        }
+      }, this.SSE_HEARTBEAT_INTERVAL_MS);
     });
 
     this.app.post("/messages", async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary

Fixes the intermittent hang where Claude Code receives no response after a command completes (see #8).

The `/sse` transport in `mcpService.ts` had **no keep-alive ping and no half-open-connection detection**. The only teardown was `res.on("close", ...)`, which doesn't fire on a half-open socket (idle timeout / NAT reaping / sleep). While a command runs, an idle SSE stream can be silently dropped; when the command finishes, the handler writes the result into the dead socket and the client hangs forever.

This PR:
- Adds a periodic SSE comment heartbeat (`: ping`, every 15s) to keep the stream alive across idle gaps and to surface a dead socket via a failed write.
- Adds a `res.on("error", ...)` handler (previously only `close` was handled).
- Consolidates teardown into one `cleanup()` that clears the heartbeat interval and removes the transport.
- Starts the heartbeat **after** `server.connect()` so the SDK writes its SSE headers + initial endpoint event first.

## Root cause (how it was localized)

Detailed in #8. Boundary test: the same handler called over the plain HTTP API (`POST /api/tool/exec_command`, bypassing SSE) returns in 0s with correct output, while the SSE path hangs — and the hung command's terminal buffer shows it completed cleanly with both markers and exit code 0. So the tool logic is fine; the response is lost on the SSE channel.

## Verification

1. **Type-check** of the exact API surface (`res.write`/`writableEnded`/`destroyed`/`on`, `ReturnType<typeof setInterval>`) — clean.
2. **Transport-layer integration test** using the real `@modelcontextprotocol/sdk` SSEServerTransport + a real MCP `Client` with the modified handler:
   - tool roundtrip still delivered correctly,
   - `: ping` heartbeats emitted on schedule,
   - transport cleaned up on disconnect.
3. **Live in Tabby**: patched the installed bundle and restarted Tabby; reading the real `localhost:3001/sse` stream shows `: ping` arriving every 15s (the unpatched v1.0.2 emits none), confirming the new handler path is active.

## Notes / scope

- This addresses the hang **trigger** (idle reaping) and adds dead-socket detection. It does not re-deliver a response lost in the exact instant between command completion and the write. Adding an overall timeout to the output-wait loop in `exec-command-tool.ts` (defense-in-depth) and/or migrating to the Streamable HTTP transport would harden this further, but are out of scope here.
